### PR TITLE
Support Xcode 14

### DIFF
--- a/lib/fastlane/plugin/periphery/actions/periphery_action.rb
+++ b/lib/fastlane/plugin/periphery/actions/periphery_action.rb
@@ -1,4 +1,5 @@
 require 'fastlane/action'
+require 'fastlane_core/helper'
 
 module Fastlane
   module Actions
@@ -103,10 +104,18 @@ module Fastlane
 
           # Alternatively, use the derived data path defined by a prior action
           derived_data_path = find_derived_data_path
-          return File.join(derived_data_path, 'Index', 'DataStore') unless derived_data_path.nil?
 
           # Fail if we couldn't automatically resolve the path
-          UI.user_error!("The index store path could not be resolved. Either specify it using the index_store_path argument or provide a path to derived data when using build_app or xcodebuild actions.")
+          if derived_data_path.nil?
+            UI.user_error!("The index store path could not be resolved. Either specify it using the index_store_path argument or provide a path to derived data when using build_app or xcodebuild actions.")
+          end
+
+          # https://github.com/peripheryapp/periphery#xcode
+          if Helper.xcode_at_least?("14.0.0")
+            return File.join(derived_data_path, 'Index.noindex', 'DataStore')
+          else
+            return File.join(derived_data_path, 'Index', 'DataStore')
+          end
         end
 
         def find_derived_data_path


### PR DESCRIPTION
https://github.com/peripheryapp/periphery#xcode

> The index store generated by xcodebuild exists in DerivedData at a location dependent on your project, e.g ~/Library/Developer/Xcode/DerivedData/YourProject-abc123/Index/DataStore. For Xcode 14 and later, the Index directory can be found as Index.noindex, which suppresses Spotlight indexing.

