### PR TITLE
Limit `PERIPHERY_RESULTS` output logged to console when lane execution fails

### DIFF
--- a/fastlane-plugin-periphery.gemspec
+++ b/fastlane-plugin-periphery.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = 'liam.nichols.ln@gmail.com'
 
   spec.summary       = 'Identifies unused code in Swift projects using Periphery'
-  # spec.homepage      = "https://github.com/<GITHUB_USERNAME>/fastlane-plugin-periphery"
+  spec.homepage      = "https://github.com/liamnichols/fastlane-plugin-periphery"
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,8 @@
 lane :test do
-  periphery(executable: 'bin/periphery_2_8_0', config: 'fixtures/MyProject/.periphery.yml')
+  periphery(executable: 'bin/periphery_2_12_3', config: 'fixtures/MyProject/.periphery.yml')
 end
 
 lane :test_from_xcodebuild do
   xcodebuild(project: 'fixtures/MyProject/MyProject.xcodeproj', scheme: 'MyProject', derivedDataPath: './tmp/derivedData/')
-  periphery(executable: 'bin/periphery_2_8_0', config: 'fixtures/MyProject/.periphery.yml', skip_build: true)
+  periphery(executable: 'bin/periphery_2_12_3', config: 'fixtures/MyProject/.periphery.yml', skip_build: true)
 end

--- a/lib/fastlane/plugin/periphery/actions/periphery_action.rb
+++ b/lib/fastlane/plugin/periphery/actions/periphery_action.rb
@@ -24,6 +24,19 @@ module Fastlane
         end
       end
 
+      # fastlane dumps the 'Lane Context' when an action fails
+      # Because the results array can contain thousands of items,
+      # we don't want to dump them all in the console.
+      # Instead, use a custom array which limits the output
+      #
+      # https://github.com/liamnichols/fastlane-plugin-periphery/issues/2
+      class Results < Array
+        def to_s
+          return super.to_s if length < 2
+          "[#{first.inspect}, ...] (#{length} items)"
+        end
+      end
+
       class Runner
         attr_reader :executable, :config, :skip_build, :index_store_path, :results
 
@@ -67,7 +80,7 @@ module Fastlane
           })
 
           # Decode the JSON output and assign to the property/lane_context
-          @results = JSON.parse(output).map { |raw| Result.new(raw) }
+          @results = Results.new(JSON.parse(output).map { |raw| Result.new(raw) })
           Actions.lane_context[SharedValues::PERIPHERY_RESULTS] = results
         end
 

--- a/lib/fastlane/plugin/periphery/version.rb
+++ b/lib/fastlane/plugin/periphery/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Periphery
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
# Background 

- Closes https://github.com/liamnichols/fastlane-plugin-periphery/issues/2

The `periperhy` action outputs the array of results to the `Actions.lane_context` as `PERIPHERY_RESULTS` so that it can be read by other steps that wish to do something with them (i.e track them in a database).

As a feature build into fastlane, when a lane fails, it'll print a table containing the lane context for debugging purposes, for example:

```
+-------------------+----------------------------------------------------+
|                              Lane Context                              |
+-------------------+----------------------------------------------------+
| PLATFORM_NAME     |                                                    |
| LANE_NAME         | test                                               |
| PERIPHERY_RESULTS | [#<Fastlane::Actions::PeripheryAction::Result:0x0  |
|                   | 0000001059accd8 @kind="class",                     |
|                   | @name="UnusedClass", @modifiers=[],                |
|                   | @attributes=[], @accessibility="internal",         |
|                   | @ids=["s:9MyProject11UnusedClassC"],               |
|                   | @hints=["unused"],                                 |
|                   | @location="/Users/liamnichols/Code/GitHub/liamnic  |
|                   | hols/fastlane-plugin-periphery/fixtures/MyProject  |
|                   | /MyProject/main.swift:10:7">]                      |
+-------------------+----------------------------------------------------+
[21:03:46]: Could not find action, lane or variable 'some_missing_action'. Check out the documentation for more details: https://docs.fastlane.tools/actions
```

In the above example, this is fine, but in a project such as ours where the array contains 3-4k items, this is a problem. The table printing logic in fastlane can't properly account for it and it it results in an output for us that breaks most editors as the log ends up being ~75mb 😄 While fastlane could benefit from an upstream patch to limit the length of items in the table, I gave up trying to figure out how to do that so I'm adding a fix here instead.

# Changes

In this Pull Request, I'm updating the action so that it uses a custom class called `Results` instead of an array directly. For backwards compatibility though, this class inherits from `Array` but I have overridden the `to_s` method to truncate the output to only contain a single item. If there are more than one items, the output will look something like this:

```
+-------------------+----------------------------------------------------+
|                              Lane Context                              |
+-------------------+----------------------------------------------------+
| PLATFORM_NAME     |                                                    |
| LANE_NAME         | test                                               |
| PERIPHERY_RESULTS | [#<Fastlane::Actions::PeripheryAction::Result:0x0  |
|                   | 00000014d513210 @kind="class",                     |
|                   | @name="UnusedClass", @modifiers=[],                |
|                   | @attributes=[], @accessibility="internal",         |
|                   | @ids=["s:9MyProject11UnusedClassC"],               |
|                   | @hints=["unused"],                                 |
|                   | @location="/Users/liamnichols/Code/GitHub/liamnic  |
|                   | hols/fastlane-plugin-periphery/fixtures/MyProject  |
|                   | /MyProject/main.swift:10:7">, ...] (3295 items)    |
+-------------------+----------------------------------------------------+
```

The contents of the array remain the same, the only change here is that we're cleaning up what is dumped into the console.